### PR TITLE
Add Haddock-compatible documentation to dynamicEps

### DIFF
--- a/Data/Number/Fixed.hs
+++ b/Data/Number/Fixed.hs
@@ -152,7 +152,7 @@ instance (Epsilon e) => RealFloat (Fixed e) where
 
 -----------
 
--- The call @dynmicEps r f v@ evaluates @f v@ to a precsion of @r@.
+-- | The call @dynmicEps r f v@ evaluates @f v@ to a precsion of @r@.
 dynamicEps :: forall a . Rational -> (forall e . Epsilon e => Fixed e -> a) -> Rational -> a
 dynamicEps r f v = loop (undefined :: Eps1)
   where loop :: forall x . (Epsilon x) => x -> a


### PR DESCRIPTION
Missing the vertical bar (pipe) causes the description of the function to be omitted from Haddock-generated documentation.
